### PR TITLE
apvs-049 - Made the claimant-details page specific to each claimant.

### DIFF
--- a/alpha/internal-web/app/assets/javascripts/application.js
+++ b/alpha/internal-web/app/assets/javascripts/application.js
@@ -133,7 +133,7 @@ $(document).ready(function () {
 
     'rowCallback': function (row, data, index) {
       $(row).click(function () {
-        document.location.href = 'claimant-details'
+        document.location.href = 'claimant-details/' + data._id
       })
     }
   })

--- a/alpha/internal-web/app/eligibility-client.js
+++ b/alpha/internal-web/app/eligibility-client.js
@@ -1,0 +1,75 @@
+// Include in the database.
+var mongo = require('../app/database')
+
+module.exports = {
+
+  /**
+   * Retrieve all claimants from the database.
+   * @param callback A callback defining what to do after a successful and failed get.
+   */
+  getAll: function (callback) {
+    mongo.db.collection('claimants').find().toArray(function (error, claimant) {
+      if (!error) {
+        callback(null, claimant)
+      } else {
+        callback(error, null)
+      }
+    })
+  },
+
+  /**
+   * Retrieve a single claimant from the database by claimant ID.
+   * @param id The id of the claimant to retrieve.
+   * @param callback A callback defining what to do after a successful and failed get.
+   */
+  get: function (id, callback) {
+    mongo.db.collection('claimants').findOne({ _id: mongoId(id) }, function (error, claimant) {
+      if (!error) {
+        callback(null, claimant)
+      } else {
+        callback(error, null)
+      }
+    })
+  },
+
+  /**
+   * Save a new claimant to the database.
+   * @param claimant The claimant details to save.
+   * @param callback A callback defining what to do after a successful and failed save.
+   */
+  save: function (claimant, callback) {
+    mongo.db.collection('claimants').insertOne(claimant, function (error, savedClaimant) {
+      if (!error) {
+        callback(null, savedClaimant)
+      } else {
+        callback(error, null)
+      }
+    })
+  },
+
+  /**
+   * Update an existing claimant.
+   * @param id The id of the claimant to update.
+   * @param claimant The claimant details to use for the update.
+   * @param callback A callback defining what to do after a successful and failed update.
+   */
+  update: function (id, claimant, callback) {
+    mongo.db.collection('claimants').updateOne({ _id: mongoId(id) }, { $set: claimant }, function (error, updatedClaimant) {
+      if (!error) {
+        callback(null, updatedClaimant)
+      } else {
+        callback(error, null)
+      }
+    })
+  }
+
+}
+
+/**
+ * Takes a string and wraps it as a Mongo ObjectID.
+ * @param id The string to wrap as a Mongo ID.
+ * @returns {ObjectID} A Mongo ObjectID suitable for making queries into a Mongo database.
+ */
+function mongoId (id) {
+  return new mongo.client.ObjectID(id)
+}

--- a/alpha/internal-web/app/routes.js
+++ b/alpha/internal-web/app/routes.js
@@ -1,42 +1,9 @@
 var express = require('express')
 var router = express.Router()
-var mongo = require('./database')
 
 module.exports = router
 
-/**
- * Render the landing page with the claimants currently stored in the database.
- */
-router.get('/', function (request, response) {
-  response.render('index')
-})
-
-/**
- * Retrieve all claimants in the system.
- */
-router.get('/claimants', function (request, response) {
-  mongo.db.collection('claimants').find().toArray(function (error, results) {
-    if (!error) {
-      console.log('Returning all claimants.')
-      // Append 'data' to the JSON object. Required by the DataTable library.
-      var claimants = { data: results }
-      response.json(claimants)
-    }
-  })
-})
-
-/**
- * Retrieve a single claimant by their claimant ID.
- */
-router.get('/claimant/:claimant_id', function (request, response) {
-  var id = new mongo.client.ObjectID(request.params.claimant_id)
-  console.log('Retrieving claimant with ID: ' + id)
-
-  mongo.db.collection('claimants').find({ _id: id }).toArray(function (error, results) {
-    if (!error) {
-      console.log('Returning claimant:')
-      console.log(results)
-      response.json(results)
-    }
-  })
-})
+// Include custom route files.
+require('./routes/index')
+require('./routes/claimants')
+require('./routes/claimant-details')

--- a/alpha/internal-web/app/routes/claimant-details.js
+++ b/alpha/internal-web/app/routes/claimant-details.js
@@ -1,0 +1,25 @@
+/**
+ * This file defines all routes for the claimant-details page.
+ */
+var router = require('../routes')
+
+// A client used to make database calls.
+var client = require('../eligibility-client')
+
+/**
+ * Retrieve all claimants in the system.
+ */
+router.get('/claimant-details/:claimant_id', function (request, response) {
+  var id = request.params.claimant_id
+  console.log('GET /claimant-details/' + id + ' called.')
+
+  client.get(id, function (error, claimant) {
+    if (!error) {
+      console.log('Successfully retrieved details for claimant with id: ' + id)
+      response.render('claimant-details', { 'claimant': claimant })
+    } else {
+      console.log('Failed to retrieve claimant with id: ' + id)
+      response.status(500).render('error', { message: error.message, error: error })
+    }
+  })
+})

--- a/alpha/internal-web/app/routes/claimants.js
+++ b/alpha/internal-web/app/routes/claimants.js
@@ -1,0 +1,47 @@
+/**
+ * This file defines generic routes for returning claimant JSON objects.
+ */
+var router = require('../routes')
+
+// A client used to make database calls.
+var client = require('../eligibility-client')
+
+/**
+ * Retrieve all claimants in the system.
+ */
+router.get('/claimants', function (request, response) {
+  var id = request.params.claimant_id
+  console.log('GET /claimants/' + id + ' called.')
+
+  client.getAll(function (error, claimants) {
+    if (!error) {
+      console.log('Returning all claimants.')
+
+      // Append 'data' to the JSON object. Required by the DataTable library.
+      var jsonClaimants = { data: claimants }
+      response.json(jsonClaimants)
+    } else {
+      console.log('Failed to retrieve claimants.')
+      response.status(500).render('error', { message: error.message, error: error })
+    }
+  })
+})
+
+/**
+ * Retrieve a single claimant by their claimant ID.
+ */
+router.get('/claimants/:claimant_id', function (request, response) {
+  var id = request.params.claimant_id
+  console.log('GET /claimants/' + id + ' called.')
+
+  client.get(id, function (error, claimant) {
+    if (!error) {
+      console.log('Returning claimant:')
+      console.log(claimant)
+      response.json(claimant)
+    } else {
+      console.log('Failed to retrieve claimants')
+      response.status(500).render('error', { message: error.message, error: error })
+    }
+  })
+})

--- a/alpha/internal-web/app/routes/claimants.js
+++ b/alpha/internal-web/app/routes/claimants.js
@@ -10,8 +10,7 @@ var client = require('../eligibility-client')
  * Retrieve all claimants in the system.
  */
 router.get('/claimants', function (request, response) {
-  var id = request.params.claimant_id
-  console.log('GET /claimants/' + id + ' called.')
+  console.log('GET /claimants/ called.')
 
   client.getAll(function (error, claimants) {
     if (!error) {

--- a/alpha/internal-web/app/routes/index.js
+++ b/alpha/internal-web/app/routes/index.js
@@ -1,0 +1,11 @@
+/**
+ * This file defines all routes for the index page.
+ */
+var router = require('../routes')
+
+/**
+ * Render the landing page with the claimants currently stored in the database.
+ */
+router.get('/', function (request, response) {
+  response.render('index')
+})

--- a/alpha/internal-web/app/views/claimant-details.html
+++ b/alpha/internal-web/app/views/claimant-details.html
@@ -1,9 +1,7 @@
 {% extends "layout.html" %}
 
-<!-- TODO: Add claimant id or name in the title. -->
-
 {% block page_title %}
-Claimant Details
+{{ claimant['first-name'] }} {{ claimant['last-name'] }} Claimant Details
 {% endblock %}
 
 {% block content %}
@@ -11,11 +9,12 @@ Claimant Details
 <main id="content" role="main">
     {% include "includes/phase_banner_alpha.html" %}
 
-
     <div class="grid-row">
         <div class="column-two-thirds">
 
-            <h1>Placeholder Details Page.</h1>
+            <p>First Name: {{ claimant['first-name'] }}</p>
+            <p>Last Name: {{ claimant['last-name'] }}</p>
+            <p>Date of Birth: {{ claimant['dob-day'] }}/{{claimant['dob-month'] }}/{{claimant['dob-year']}}</p>
 
         </div>
 
@@ -24,5 +23,3 @@ Claimant Details
 </main>
 
 {% endblock %}
-
-

--- a/alpha/internal-web/app/views/error.html
+++ b/alpha/internal-web/app/views/error.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+{% if serviceName %} {{ serviceName }} {% endif %}
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+    {% include "includes/phase_banner_alpha.html" %}
+
+    <br>
+
+    <!-- Display error. -->
+    <h2>{{ error }}</h2>
+
+</main>
+
+{% endblock %}

--- a/alpha/internal-web/public/javascripts/application.js
+++ b/alpha/internal-web/public/javascripts/application.js
@@ -111,20 +111,30 @@ $(document).ready(function () {
   toggleContent.showHideRadioToggledContent()
   toggleContent.showHideCheckboxToggledContent()
 
+  // Initialise DataTable used for displaying list of claimants.
   var dataUrl = 'http://localhost:3001/claimants'
   $('#claimants-table').DataTable({
+
     ajax: dataUrl,
+
     columns: [
       { 'data': '_id' },
-      { 'data': 'first_name' },
-      { 'data': 'last_name' }
+      { 'data': 'first-name' },
+      { 'data': 'last-name' }
     ],
+
     columnDefs: [
       {
         'targets': [ 0 ],
         'visible': false,
         'searchable': false
       }
-    ]
+    ],
+
+    'rowCallback': function (row, data, index) {
+      $(row).click(function () {
+        document.location.href = 'claimant-details/' + data._id
+      })
+    }
   })
 })


### PR DESCRIPTION
The links defined in the DataTable now specify the claimants ID.
The claimant-details page now has a title that includes the claimants name.
claimant-details now displays some basic claimant information.
Removed completed TODOs.
Split routes out into files based on which page they are related to.
Brought over the eligibility-client from external web and hooked it into the internal routes.
Included an error page that users are now redirected to if a mongo call fails.
Updated routes.js to point at the new routes files.
