### PR TITLE
Feature/apvs 022/added middleware style logging

### DIFF
--- a/alpha/external-web/app/database.js
+++ b/alpha/external-web/app/database.js
@@ -2,7 +2,7 @@
  * This file defines the database connection to Mongodb.
  */
 var client = require('mongodb')
-var logger = require('./services/bunyan-logger').logger
+var logger = require('./services/bunyan-logger')
 exports.client = client
 
 client.connect('mongodb://mongo:27017/apvs', function (error, database) {

--- a/alpha/external-web/app/routes.js
+++ b/alpha/external-web/app/routes.js
@@ -1,6 +1,7 @@
 var express = require('express')
-var router = express.Router()
+var logger = require('./services/bunyan-logger')
 
+var router = express.Router()
 module.exports = router
 
 // Include custom route files.
@@ -12,3 +13,14 @@ require('./routes/about-your-income')
 require('./routes/application-submitted')
 require('./routes/claim')
 require('./routes/claim-details')
+
+// Executed prior to any route being called.
+router.use(function (request, response, next) {
+  logger.info({ request: request }, 'Route Started.')
+  next()
+})
+
+// Executed after any route completes.
+router.use(function (request, response) {
+  logger.info({ response: response }, 'Route Complete.')
+})

--- a/alpha/external-web/app/routes/about-you.js
+++ b/alpha/external-web/app/routes/about-you.js
@@ -1,48 +1,44 @@
 var router = require('../routes')
 var client = require('../eligibility-client')
 var eligibilityFlag = require('../services/eligibility-flag')
-var logger = require('../services/bunyan-logger').logger
+var logger = require('../services/bunyan-logger')
 
 var PENDING = 'PENDING'
 
-router.get('/about-you', function (request, response) {
-  logger.info({request: request})
+router.get('/about-you', function (request, response, next) {
   response.render('about-you')
-  logger.info({response: response})
+  next()
 })
 
-router.get('/about-you/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/about-you/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.render('about-you', { 'claimant': claimant })
-      logger.info({response: response}, 'Successfully retrieved claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })
 
-router.post('/about-you', function (request, response) {
-  logger.info({request: request})
+router.post('/about-you', function (request, response, next) {
   save(null, request, response)
-  logger.info({response: response})
+  next()
 })
 
-router.post('/about-you/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.post('/about-you/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   eligibilityFlag.get(id, function (isEligibilityModified) {
     if (isEligibilityModified) {
       logger.info('This is a modification of an eligibility application. Saving new record.')
       save(id, request, response)
+      next()
     } else {
       logger.info('This is a brand new eligibility application.')
       update(id, request, response)
+      next()
     }
   })
 })
@@ -60,10 +56,8 @@ function save (id, request, response) {
   client.save(claimant, function (error, claimant) {
     if (!error) {
       response.redirect('/relationship/' + claimant._id)
-      logger.info({response: response}, 'Successfully saved new claimant.')
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.info({response: response}, 'Failed to save new claimant.')
     }
 
     // If we were directed here from the claim page mark the new eligibility claim as being a modification.
@@ -82,13 +76,11 @@ function update (id, request, response) {
     personal: request.body
   }
 
-  client.update(id, claimant, function (error, claimant) {
+  client.update(id, claimant, function (error) {
     if (!error) {
       response.redirect('/relationship/' + id)
-      logger.info({response: response}, 'Successfully updated claimant with id: %s', id)
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to update claimant with id: %s', id)
     }
   })
 }

--- a/alpha/external-web/app/routes/about-your-income.js
+++ b/alpha/external-web/app/routes/about-your-income.js
@@ -1,34 +1,30 @@
 var router = require('../routes')
 var client = require('../eligibility-client')
 var eligibilityFlag = require('../services/eligibility-flag')
-var logger = require('../services/bunyan-logger').logger
+var logger = require('../services/bunyan-logger')
 
 // Require file upload library.
 var multer = require('multer')
 var upload = multer({ dest: 'eligibility-uploads/' })
 
-router.get('/about-your-income/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/about-your-income/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.render('about-your-income', { 'claimant': claimant })
-      logger.info({response: response}, 'Successfully retrieved claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })
 
-router.post('/about-your-income/:claimant_id', upload.single('evidence'), function (request, response) {
-  logger.info({request: request})
-
+router.post('/about-your-income/:claimant_id', upload.single('evidence'), function (request, response, next) {
   var id = request.params.claimant_id
   if (!request.file) {
     response.status(500).render('error', { error: 'Failed to update claimant with id: ' + id + '. No file was uploaded.' })
-    logger.error({response: response}, 'Failed to update claimant with id: %s. No file was uploaded.', id)
+    next()
   } else {
     var incomeDetails = {
       'eligibility-file': {
@@ -44,17 +40,17 @@ router.post('/about-your-income/:claimant_id', upload.single('evidence'), functi
         logger.info('Successfully updated claimant with id: %s', id)
       } else {
         response.status(500).render('error', { message: error.message, error: error })
-        logger.error({response: response}, 'Failed to update claimant with id: %s', id)
+        next()
       }
     })
 
     eligibilityFlag.get(id, function (isEligibilityModified) {
       if (isEligibilityModified) {
         response.redirect('/claim-details/' + id)
-        logger.info({response: response}, 'Modified eligibility application submitted successfully. Redirecting user to claim details.')
+        next()
       } else {
         response.redirect('/application-submitted')
-        logger.info({response: response}, 'New eligibility application submitted successfully. Redirecting user to success page.')
+        next()
       }
     })
   }

--- a/alpha/external-web/app/routes/application-submitted.js
+++ b/alpha/external-web/app/routes/application-submitted.js
@@ -1,8 +1,6 @@
 var router = require('../routes')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/application-submitted', function (request, response) {
-  logger.info({request: request})
+router.get('/application-submitted', function (request, response, next) {
   response.render('application-submitted')
-  logger.info({response: response})
+  next()
 })

--- a/alpha/external-web/app/routes/claim-details.js
+++ b/alpha/external-web/app/routes/claim-details.js
@@ -1,14 +1,11 @@
 var router = require('../routes')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/claim-details/:claimant_id', function (request, response) {
-  logger.info({request: request})
+router.get('/claim-details/:claimant_id', function (request, response, next) {
   response.render('claim-details')
-  logger.info({response: response})
+  next()
 })
 
 // TODO
-router.post('/claim-details/:claimant_id', function (request, response) {
-  logger.info({request: request})
-  logger.info({response: response})
+router.post('/claim-details/:claimant_id', function (request, response, next) {
+  next()
 })

--- a/alpha/external-web/app/routes/claim.js
+++ b/alpha/external-web/app/routes/claim.js
@@ -1,40 +1,36 @@
 var router = require('../routes')
 var eligibilityFlag = require('../services/eligibility-flag')
 var reference = require('../services/reference-checker')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/claim', function (request, response) {
-  logger.info({request: request})
+router.get('/claim', function (request, response, next) {
   response.render('claim')
-  logger.info({response: response})
+  next()
 })
 
-router.post('/claim', function (request, response) {
-  logger.info({request: request})
-
+router.post('/claim', function (request, response, next) {
   var id = request.body.reference
   var eligibility = request.body.isEligibilityModified
 
   if (!eligibility) {
     response.status(500).render('error', { error: 'Request Failed! Please fully complete the form.' })
-    logger.error({response: response}, 'Claim Submit Failed! Form was not complete.')
+    next()
     return
   }
 
   reference.isValid(id, function (isValid) {
     if (!isValid) {
       response.redirect('/index')
-      logger.error({response: response}, 'Claim Submit Failed! Reference %s was not valid.', id)
+      next()
       return
     }
     eligibilityFlag.update(id, eligibility)
 
     if (eligibilityFlag.isModified(eligibility)) {
       response.redirect('/about-you/' + id)
-      logger.error({response: response}, 'Eligibility claim with reference %s has been modified redirecting to eligibility application.', id)
+      next()
       return
     }
     response.redirect('/claim-details/' + id)
-    logger.error({response: response}, 'Eligibility claim with reference %s has not been modified proceeding to claim details.', id)
+    next()
   })
 })

--- a/alpha/external-web/app/routes/escorts.js
+++ b/alpha/external-web/app/routes/escorts.js
@@ -1,25 +1,20 @@
 var router = require('../routes')
 var client = require('../eligibility-client')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/escorts/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/escorts/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.render('escorts', { 'claimant': claimant })
-      logger.info({response: response}, 'Successfully retrieved claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })
 
-router.post('/escorts/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.post('/escorts/:claimant_id', function (request, response, next) {
   var escorts = {
     'escorts': request.body
   }
@@ -28,10 +23,10 @@ router.post('/escorts/:claimant_id', function (request, response) {
   client.update(id, escorts, function (error, claimant) {
     if (!error) {
       response.redirect('/about-your-income/' + id)
-      logger.info({response: response}, 'Successfully updated claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to update claimant with id: %s', id)
+      next()
     }
   })
 })

--- a/alpha/external-web/app/routes/index.js
+++ b/alpha/external-web/app/routes/index.js
@@ -1,8 +1,6 @@
 var router = require('../routes')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/', function (request, response) {
-  logger.info({request: request})
+router.get('/', function (request, response, next) {
   response.render('index')
-  logger.info({response: response})
+  next()
 })

--- a/alpha/external-web/app/routes/relationship.js
+++ b/alpha/external-web/app/routes/relationship.js
@@ -1,25 +1,21 @@
 var router = require('../routes')
 var client = require('../eligibility-client')
-var logger = require('../services/bunyan-logger').logger
+var logger = require('../services/bunyan-logger')
 
-router.get('/relationship/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/relationship/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.render('relationship', { 'claimant': claimant })
-      logger.info({response: response}, 'Successfully retrieved claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })
 
-router.post('/relationship/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.post('/relationship/:claimant_id', function (request, response, next) {
   var relationship = {
     'relationship': request.body
   }
@@ -32,14 +28,14 @@ router.post('/relationship/:claimant_id', function (request, response) {
       // Redirect the user based on the response to the escort question.
       if (request.body.escort === 'Yes') {
         response.redirect('/escorts/' + id)
-        logger.info({response: response}, 'Claimant with id: %s has an escort.', id)
+        next()
       } else {
         response.redirect('/about-your-income/' + id)
-        logger.info({response: response}, 'Claimant with id: %s does not have an escort.', id)
+        next()
       }
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error('Failed to update claimant with id: %s', id)
+      next()
     }
   })
 })

--- a/alpha/external-web/app/services/bunyan-logger.js
+++ b/alpha/external-web/app/services/bunyan-logger.js
@@ -5,7 +5,7 @@ var PrettyStream = require('bunyan-prettystream')
 var prettyStream = new PrettyStream()
 prettyStream.pipe(process.stdout)
 
-exports.logger = bunyan.createLogger({
+var logger = bunyan.createLogger({
   name: 'external',
   streams: [
     {
@@ -36,3 +36,5 @@ function responseSerializer (response) {
     statusCode: response.statusCode
   }
 }
+
+module.exports = logger

--- a/alpha/external-web/app/services/database.js
+++ b/alpha/external-web/app/services/database.js
@@ -2,7 +2,7 @@
  * This file defines the database connection to Mongodb.
  */
 var client = require('mongodb')
-var logger = require('./bunyan-logger').logger
+var logger = require('./bunyan-logger')
 exports.client = client
 
 client.connect('mongodb://mongo:27017/apvs', function (error, database) {

--- a/alpha/external-web/app/services/eligibility-flag.js
+++ b/alpha/external-web/app/services/eligibility-flag.js
@@ -7,7 +7,7 @@
  *   claim via the 'Claim Now button on the index page'.
  */
 var client = require('../eligibility-client')
-var logger = require('./bunyan-logger').logger
+var logger = require('./bunyan-logger')
 
 exports.isModified = function (eligibility) {
   return eligibility === 'Yes'

--- a/alpha/external-web/app/services/reference-checker.js
+++ b/alpha/external-web/app/services/reference-checker.js
@@ -1,5 +1,5 @@
 var client = require('../eligibility-client')
-var logger = require('./bunyan-logger').logger
+var logger = require('./bunyan-logger')
 
 exports.isValid = function (reference, callback) {
   if (client.isValidMongoId(reference)) {

--- a/alpha/external-web/app/views/index.html
+++ b/alpha/external-web/app/views/index.html
@@ -57,11 +57,11 @@
             <p>You might not need to answer all the questions, depending on your circumstances. </p>
 
             <p>
-                <a class="button button-start" href="about-you.html" role="button">Start now</a>
+                <a class="button button-start" href="/about-you" role="button">Start now</a>
             </p>
 
             <p>
-                <a class="button button-start" href="claim.html" role="button">Claim Now</a>
+                <a class="button button-start" href="/claim" role="button">Claim Now</a>
             </p>
 
             <h2 class="heading-medium">Before you start</h2>

--- a/alpha/internal-web/app/routes.js
+++ b/alpha/internal-web/app/routes.js
@@ -1,4 +1,6 @@
 var express = require('express')
+var logger = require('./services/bunyan-logger')
+
 var router = express.Router()
 
 module.exports = router
@@ -8,3 +10,14 @@ require('./routes/index')
 require('./routes/claimants')
 require('./routes/claimant-details')
 require('./routes/api')
+
+// Executed prior to any route being called.
+router.use(function (request, response, next) {
+  logger.info({ request: request }, 'Route Started.')
+  next()
+})
+
+// Executed after any route completes.
+router.use(function (request, response) {
+  logger.info({ response: response }, 'Route Complete.')
+})

--- a/alpha/internal-web/app/routes/api.js
+++ b/alpha/internal-web/app/routes/api.js
@@ -1,17 +1,14 @@
 var router = require('../routes')
 var client = require('../services/eligibility-client')
-var logger = require('../services/bunyan-logger').logger
 
-router.post('/api/income-check', function (request, response) {
-  logger.info({request: request})
-
+router.post('/api/income-check', function (request, response, next) {
   var id = request.body.id
   var status = getIncomeStatus()
 
   client.update(id, status, function (error, claimant) {
     if (error) {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to change claimants income verification status to %s. ID: %s', status['status.relationshipVerificationStatus'], id)
+      next()
     }
     response.json(status)
   })
@@ -25,19 +22,17 @@ function getIncomeStatus () {
   }
 }
 
-router.post('/api/relationship-check/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.post('/api/relationship-check/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   var status = getRelationshipStatus()
 
   client.update(id, status, function (error, claimant) {
     if (!error) {
       response.redirect('/claimant-details/' + id)
-      logger.info({response: response}, 'Successfully changed claimants relationship verification status to %s. ID: %s', status['status.relationshipVerificationStatus'], id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to change claimants relationship verification status to %s. ID: %s', status['status.relationshipVerificationStatus'], id)
+      next()
     }
   })
 })

--- a/alpha/internal-web/app/routes/claimant-details.js
+++ b/alpha/internal-web/app/routes/claimant-details.js
@@ -1,6 +1,5 @@
 var router = require('../routes')
 var client = require('../services/eligibility-client')
-var logger = require('../services/bunyan-logger').logger
 
 // Valid Statuses for a claimant application.
 var APPLICATION_STATUS = {
@@ -9,37 +8,32 @@ var APPLICATION_STATUS = {
   ESCALATED: 'ESCALATED'
 }
 
-router.get('/claimant-details/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/claimant-details/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.render('claimant-details', { 'claimant': claimant })
-      logger.info({response: response}, 'Successfully retrieved details for claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })
 
-router.post('/claimant-details/:claimant_id/approve', function (request, response) {
-  logger.info({request: request})
-  updateApplicationStatus(APPLICATION_STATUS.APPROVED, request, response)
+router.post('/claimant-details/:claimant_id/approve', function (request, response, next) {
+  updateApplicationStatus(APPLICATION_STATUS.APPROVED, request, response, next)
 })
 
-router.post('/claimant-details/:claimant_id/reject', function (request, response) {
-  logger.info({request: request})
-  updateApplicationStatus(APPLICATION_STATUS.REJECTED, request, response)
+router.post('/claimant-details/:claimant_id/reject', function (request, response, next) {
+  updateApplicationStatus(APPLICATION_STATUS.REJECTED, request, response, next)
 })
 
-router.post('/claimant-details/:claimant_id/escalate', function (request, response) {
-  logger.info({request: request})
-  updateApplicationStatus(APPLICATION_STATUS.ESCALATED, request, response)
+router.post('/claimant-details/:claimant_id/escalate', function (request, response, next) {
+  updateApplicationStatus(APPLICATION_STATUS.ESCALATED, request, response, next)
 })
 
-function updateApplicationStatus (status, request, response) {
+function updateApplicationStatus (status, request, response, next) {
   var updatedStatus = {
     'status.applicationStatus': status
   }
@@ -48,26 +42,25 @@ function updateApplicationStatus (status, request, response) {
   client.update(id, updatedStatus, function (error, claimant) {
     if (!error) {
       response.redirect('/claimant-details/' + id)
-      logger.info({response: response}, 'Successfully changed claimants application status to %s. ID: %s', updatedStatus, id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to change claimants application status to %s. ID: %s', updatedStatus, id)
+      next()
     }
   })
 }
 
-router.get('/claimant-details/:claimant_id/evidence/:eligibility_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/claimant-details/:claimant_id/evidence/:eligibility_id', function (request, response, next) {
   var id = request.params.claimant_id
   var eligibilityId = request.params.eligibility_id
+
   client.get(id, function (error, claimant) {
     if (!error) {
       response.download('./eligibility-uploads/' + eligibilityId, claimant[ 'eligibility-file' ][ 'originalFilename' ])
-      logger.info({response: response}, 'Successfully retrieved details for claimant with id: %s', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with id: %s', id)
+      next()
     }
   })
 })

--- a/alpha/internal-web/app/routes/claimants.js
+++ b/alpha/internal-web/app/routes/claimants.js
@@ -1,34 +1,29 @@
 var router = require('../routes')
 var client = require('../services/eligibility-client')
-var logger = require('../services/bunyan-logger').logger
 
 // Append 'data' to the JSON object as this is required by the DataTable library.
-router.get('/claimants', function (request, response) {
-  logger.info({request: request})
-
+router.get('/claimants', function (request, response, next) {
   client.getAll(function (error, claimants) {
     if (!error) {
       var jsonClaimants = { data: claimants }
       response.json(jsonClaimants)
-      logger.info({response: response}, 'Returning all claimants.')
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve all claimants.')
+      next()
     }
   })
 })
 
-router.get('/claimants/:claimant_id', function (request, response) {
-  logger.info({request: request})
-
+router.get('/claimants/:claimant_id', function (request, response, next) {
   var id = request.params.claimant_id
   client.get(id, function (error, claimant) {
     if (!error) {
       response.json(claimant)
-      logger.info({response: response}, 'Returning claimant with ID: %s.', id)
+      next()
     } else {
       response.status(500).render('error', { message: error.message, error: error })
-      logger.error({response: response}, 'Failed to retrieve claimant with ID: %s.', id)
+      next()
     }
   })
 })

--- a/alpha/internal-web/app/routes/index.js
+++ b/alpha/internal-web/app/routes/index.js
@@ -1,23 +1,19 @@
 var router = require('../routes')
 var client = require('../services/eligibility-client')
-var logger = require('../services/bunyan-logger').logger
 
-router.get('/', function (request, response) {
-  logger.info({request: request})
+router.get('/', function (request, response, next) {
   response.render('index')
-  logger.info({response: response})
+  next()
 })
 
-router.get('/clean', function (request, response) {
-  logger.info({request: request})
-
+router.get('/clean', function (request, response, next) {
   client.drop(function (error) {
     if (!error) {
       response.redirect('/')
-      logger.info({response: response}, 'Successfully dropped all claimant details.')
+      next()
     } else {
       response.redirect('/')
-      logger.error({response: response}, 'Failed to drop all claimant details.')
+      next()
     }
   })
 })

--- a/alpha/internal-web/app/services/bunyan-logger.js
+++ b/alpha/internal-web/app/services/bunyan-logger.js
@@ -5,7 +5,7 @@ var PrettyStream = require('bunyan-prettystream')
 var prettyStream = new PrettyStream()
 prettyStream.pipe(process.stdout)
 
-exports.logger = bunyan.createLogger({
+var logger = bunyan.createLogger({
   name: 'internal',
   streams: [
     {
@@ -36,3 +36,5 @@ function responseSerializer (response) {
     statusCode: response.statusCode
   }
 }
+
+module.exports = logger

--- a/alpha/internal-web/app/services/database.js
+++ b/alpha/internal-web/app/services/database.js
@@ -1,7 +1,7 @@
 /**
  * This file defines the database connection to Mongodb.
  */
-var logger = require('./bunyan-logger').logger
+var logger = require('./bunyan-logger')
 var client = require('mongodb')
 exports.client = client
 


### PR DESCRIPTION
- Defined middleware style before and after methods.
- Before prints the request.
- After prints the response.
- These new methods are now called before and after, respectively, each route called.
- Removed logging statements that are now handled by the before and after calls, and the logger itself when no longer being used in the file.
- index.html was referencing about-you.html and claim.html instead of /about-you and /claim this meant it was not working with the routes correctly.

Set the modules export name for the logger explicitly to remove the need to reference the logger object in each class:

Was:
`var logger = require('../services/bunyan-logger').logger`

Now:
`var logger = require('../services/bunyan-logger')`
