### PR TITLE
Fixed bug.

### DIFF
--- a/alpha/external-web/app/services/bunyan-logger.js
+++ b/alpha/external-web/app/services/bunyan-logger.js
@@ -12,6 +12,7 @@ prettyStream.pipe(process.stdout)
 // Create a base logger for the application.
 var logger = bunyan.createLogger({
   name: 'external',
+  streams: [],
   serializers: {
     'request': requestSerializer,
     'response': responseSerializer

--- a/alpha/internal-web/app/services/bunyan-logger.js
+++ b/alpha/internal-web/app/services/bunyan-logger.js
@@ -12,6 +12,7 @@ prettyStream.pipe(process.stdout)
 // Create a base logger for the application.
 var logger = bunyan.createLogger({
   name: 'internal',
+  streams: [],
   serializers: {
     'request': requestSerializer,
     'response': responseSerializer


### PR DESCRIPTION
- Bunyan was adding in a default log to console as no streams where being provided in the logger's initial construction.
- The loggers streams array is now set to an empty array, such that only the stream we explicitly add are included.
