### PR TITLE
Feature/apvs 280/set upload size limit and type white list

### DIFF
--- a/alpha/external-web/app/routes/about-your-income.js
+++ b/alpha/external-web/app/routes/about-your-income.js
@@ -1,28 +1,6 @@
 var router = require('../routes')
 var client = require('../services/eligibility-client')
-
-const maxFileSize = 5242880 // 5MB in Bytes.
-const allowedFileTypes = ['image/png', 'image/jpeg', 'application/pdf']
-
-function fileFilter (req, file, callback) {
-  var mimeType = file.mimetype
-
-  if (!allowedFileTypes.includes(mimeType)) {
-    var error = 'Uploaded file was not an image.'
-    req.fileValidationError = error
-    return callback(null, false, new Error(error))
-  }
-  callback(null, true)
-}
-
-// Require file upload library.
-var multer = require('multer')({
-  dest: 'eligibility-uploads/',
-  limits: {
-    fileSize: maxFileSize
-  },
-  fileFilter: fileFilter
-})
+var upload = require('../services/upload')
 
 const claimantsCollection = 'claimants'
 
@@ -37,7 +15,7 @@ router.get('/about-your-income/:claimant_id', function (request, response, next)
   next()
 })
 
-router.post('/about-your-income/:claimant_id', multer.single('evidence'), function (request, response, next) {
+router.post('/about-your-income/:claimant_id', upload.single('evidence'), function (request, response, next) {
   var id = request.params.claimant_id
   if (!request.file) {
     response.status(500).render('error', { error: 'Failed to update claimant with id: ' + id + '. No file was uploaded.' })

--- a/alpha/external-web/app/services/upload.js
+++ b/alpha/external-web/app/services/upload.js
@@ -1,0 +1,21 @@
+var multer = require('multer')
+
+const maxFileSize = 5242880 // 5MB in Bytes.
+const allowedFileTypes = ['image/png', 'image/jpeg', 'application/pdf']
+
+function fileFilter (req, file, callback) {
+  if (!allowedFileTypes.includes(file.mimetype)) {
+    var error = 'Uploaded file was not an image.'
+    req.fileValidationError = error
+    return callback(null, false, new Error(error))
+  }
+  callback(null, true)
+}
+
+module.exports = multer({
+  dest: 'eligibility-uploads/',
+  limits: {
+    fileSize: maxFileSize
+  },
+  fileFilter: fileFilter
+})


### PR DESCRIPTION
## Description

Added validation to file upload.
## Impacted Areas of Application
### External web application
- We now prevent any upload that is more than 5mb.
- We now only allow the upload of the following file types: .pdf, .png, .jpeg.
- The file upload logic has been split out into a new file.
## Checklist

[] Unit tests written and passing
[X] Coding standards adhered to
[X] Coding conventions adhered to (well factored and maintainable)
[X] Error Handling
[X] Security considered
[X] Performance considered
[] Appropriate use of logging
[] README updated?
[] Comments and/or API documentation?
