### PR TITLE
Chore/set logging path by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Optional configuration for the prototype.
 ### Bunyan Logging
 The prototype uses the Bunyan Logging library to produce JSON logs which it outputs to file, console, and optionally an ELK instance (see [ELK Stack](#elk_stack)).
 
-- LOGGING_PATH :: Set where to output log files. Defaults to 'logs/external-web.log' & 'logs/internal-web.log'.
+- LOGGING_PATH :: Sets the path to output Bunyan log files. Defaults to 'logs/external-web.log' & 'logs/internal-web.log'.
 
 ### ELK Stack
 The prototype has been configured to stream log messages from the Bunyan logger to an instance of the ELK stack running in a Docker container. By default this is disabled. To enable this functionality uncomment the ELK configuration, ELK links, and the environmental defined below for both the internal and external web in the docker-compose.yml file.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ When running in development, volumes are mapped from the containers to the host 
 ## Configuration
 Optional configuration for the prototype.
 
+### Bunyan Logging
+The prototype uses the Bunyan Logging library to produce JSON logs which it outputs to file, console, and optionally an ELK instance (see [ELK Stack](#elk_stack)).
+
+- LOGGING_PATH :: Set where to output log files. Defaults to 'logs/external-web.log' & 'logs/internal-web.log'.
+
 ### ELK Stack
 The prototype has been configured to stream log messages from the Bunyan logger to an instance of the ELK stack running in a Docker container. By default this is disabled. To enable this functionality uncomment the ELK configuration, ELK links, and the environmental defined below for both the internal and external web in the docker-compose.yml file.
 

--- a/alpha/external-web/app/services/bunyan-logger.js
+++ b/alpha/external-web/app/services/bunyan-logger.js
@@ -2,6 +2,7 @@ var bunyan = require('bunyan')
 var PrettyStream = require('bunyan-prettystream')
 var bunyanLogstash = require('bunyan-logstash-tcp')
 
+var logstashPath = process.env.LOGGING_PATH || 'logs/external-web.log'
 var logstashHost = process.env.LOGSTASH_HOST
 var logstashPort = process.env.LOGSTASH_PORT
 
@@ -45,7 +46,7 @@ if (logstashHost && logstashPort) {
 logger.addStream({
   type: 'rotating-file',
   level: 'DEBUG',
-  path: '/usr/src/app/logs/external-web.log',
+  path: logstashPath,
   period: '1d',
   count: 7
 })

--- a/alpha/internal-web/app/services/bunyan-logger.js
+++ b/alpha/internal-web/app/services/bunyan-logger.js
@@ -2,7 +2,7 @@ var bunyan = require('bunyan')
 var PrettyStream = require('bunyan-prettystream')
 var bunyanLogstash = require('bunyan-logstash-tcp')
 
-var logstashPath = process.env.LOGGING_PATH || 'logs/external-web.log'
+var logstashPath = process.env.LOGGING_PATH || 'logs/internal-web.log'
 var logstashHost = process.env.LOGSTASH_HOST
 var logstashPort = process.env.LOGSTASH_PORT
 

--- a/alpha/internal-web/app/services/bunyan-logger.js
+++ b/alpha/internal-web/app/services/bunyan-logger.js
@@ -2,6 +2,7 @@ var bunyan = require('bunyan')
 var PrettyStream = require('bunyan-prettystream')
 var bunyanLogstash = require('bunyan-logstash-tcp')
 
+var logstashPath = process.env.LOGGING_PATH || 'logs/external-web.log'
 var logstashHost = process.env.LOGSTASH_HOST
 var logstashPort = process.env.LOGSTASH_PORT
 
@@ -45,7 +46,7 @@ if (logstashHost && logstashPort) {
 logger.addStream({
   type: 'rotating-file',
   level: 'DEBUG',
-  path: '/usr/src/app/logs/internal-web.log',
+  path: logstashPath,
   period: '1d',
   count: 7
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,11 +32,12 @@ services:
     depends_on:
       - mongo
       - external-api-apvs
-    #links:
-    #  - elk
-    #environment:
+    environment:
+      - LOGGING_PATH=/usr/src/app/logs/external-web.log
     #  - LOGSTASH_HOST=elk
     #  - LOGSTASH_PORT=9998
+    #links:
+    #  - elk
 
   # Build the internal facing node application and expose it on port 3001.
   node-internal-apvs:
@@ -51,11 +52,12 @@ services:
       - "3001:3001"
     depends_on:
       - mongo
-    #links:
-    #  - elk
-    #environment:
+    environment:
+      - LOGGING_PATH=/usr/src/app/logs/external-web.log
     #  - LOGSTASH_HOST=elk
     #  - LOGSTASH_PORT=9998
+    #links:
+    #  - elk
 
   # Build a mongo contianer that will serve as the database for the internal and external node applications.
   mongo:


### PR DESCRIPTION
## Description

The file path used by the bunyan logger is now set by environment variable.
## Impacted Areas of Application
### Alpha
- Updated top level README file with details of the new logging configuration.
### External web application
- Logger now uses the environmental variable if set, or otherwise defaults to 'logs/external-web.log'.
- Added an environmental variable to the docker-compose file that sets the logger to logging location in the docker container (I.e. the path we had been using up till now).
### Internal web application
- Logger now uses the environmental variable if set, or otherwise defaults to 'logs/internal-web.log'.
- Added an environmental variable to the docker-compose file that sets the logger to logging location in the docker container (I.e. the path we had been using up till now).
## Checklist
- [ ] Unit tests written and passing
- [x] Coding standards adhered to
- [ ] Error Handling
- [ ] Security considered
- [ ] Performance considered
- [x] Appropriate use of logging
- [x] README updated?
- [ ] Comments and/or API documentation?
- [ ] Updates required for deployment?
